### PR TITLE
Add static marketing site for Borscht of Energy

### DIFF
--- a/IMAGE_PLACEHOLDERS.md
+++ b/IMAGE_PLACEHOLDERS.md
@@ -1,0 +1,24 @@
+# Borscht of Energy Image Brief
+
+Use the following image plan to source or create visuals that align with the Borscht of Energy brand. Each filename matches a placeholder used within `index.html`.
+
+| Filename | Section | Description & Art Direction |
+| --- | --- | --- |
+| hero-athlete-energy.jpg | Hero | High-contrast action shot of an endurance athlete (cyclist or runner) powering through twilight with motion blur and deep crimson lighting accents. |
+| product-shot-performance.jpg | Product Highlights | Macro shot of a sleek 70–100 mL performance borscht shot bottle with metallic red cap, minimal steam, and subtle dill garnish hints. |
+| product-shot-mix.jpg | Product Highlights | Flat-lay of powder sachets, beet powder dusted artfully on dark slate, with measuring spoon and hot water carafe. |
+| product-shot-gel.jpg | Product Highlights | Dynamic angle of isotonic gel packets mid-air with droplets, emphasizing portability and savory cues. |
+| product-shot-broth.jpg | Product Highlights | Cinematic recovery broth in a double-walled glass with rising steam, surrounded by fresh herbs and beet slices. |
+| science-pathway-diagram.png | Science Feature | Stylized infographic showing nitrate → nitrite → nitric oxide pathway with anatomical silhouettes and glowing vascular lines. |
+| protocol-endurance.jpg | Protocols | Montage of cyclists prepping gear with checklists and bottles, emphasizing structured planning. |
+| protocol-hiit.jpg | Protocols | High-intensity training scene with athlete chalking hands in an industrial gym, warm red lighting. |
+| protocol-masters.jpg | Protocols | Masters athlete stretching at sunrise in an urban setting, highlighting longevity and confidence. |
+| protocol-altitude.jpg | Protocols | Trail runner or skier training at altitude with dramatic mountain backdrop and crimson sky. |
+| journal-research.jpg | Journal | Editorial image of lab glassware with beet pigments under neon accent lighting. |
+| journal-athlete-story.jpg | Journal | Portrait of elite cyclist or triathlete smiling post-race with medal and branded bottle. |
+| journal-recipe.jpg | Journal | Overhead shot of vibrant beet soup with dill and citrus zest on dark stone table. |
+| testimonials-athletes.jpg | Testimonials | Collage of athlete headshots with subtle overlays of brand gradients. |
+| cta-bundle.jpg | CTA Panel | Product bundle arrangement on matte black surface with glowing rim light and condensation. |
+| faq-savory.jpg | FAQ | Cozy close-up of steaming savory drink in athlete’s hands, showing texture and comfort. |
+| logo-placeholder.png | Global | Reserved space for the official Borscht of Energy logo. Maintain transparent background. |
+

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,638 @@
+:root {
+    --bg-dark: #040404;
+    --bg-muted: #0f0f10;
+    --bg-light: #131416;
+    --primary: #c70039;
+    --primary-light: #f04b75;
+    --accent: #ff9a1f;
+    --text-light: #f5f6f8;
+    --text-muted: #b8bcc6;
+    --border-color: rgba(255, 255, 255, 0.08);
+    --card-bg: rgba(19, 20, 22, 0.88);
+    --shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
+    --radius-lg: 28px;
+    --radius-md: 20px;
+    --radius-sm: 12px;
+    --max-width: 1200px;
+    --transition: all 0.25s ease;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Source Sans 3', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: radial-gradient(circle at 10% 10%, rgba(199, 0, 57, 0.4), transparent 50%),
+        radial-gradient(circle at 90% 20%, rgba(255, 154, 31, 0.35), transparent 55%),
+        linear-gradient(135deg, #09090a 0%, #030303 100%);
+    color: var(--text-light);
+    min-height: 100vh;
+    scroll-behavior: smooth;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--primary-light);
+}
+
+.hero {
+    position: relative;
+    padding: 32px 5vw 96px;
+    background: linear-gradient(140deg, rgba(7, 7, 7, 0.96) 0%, rgba(12, 12, 14, 0.94) 40%, rgba(30, 9, 18, 0.88) 100%);
+    overflow: hidden;
+}
+
+.hero::before,
+.hero::after {
+    content: '';
+    position: absolute;
+    width: 420px;
+    height: 420px;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.5;
+    z-index: 0;
+}
+
+.hero::before {
+    background: var(--primary);
+    top: -120px;
+    left: -140px;
+}
+
+.hero::after {
+    background: var(--accent);
+    bottom: -200px;
+    right: -160px;
+}
+
+.nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: relative;
+    z-index: 2;
+}
+
+.logo {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.logo-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    border: 2px dashed rgba(255, 255, 255, 0.35);
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+}
+
+.logo-placeholder.small {
+    width: 52px;
+    height: 52px;
+    font-size: 10px;
+}
+
+.brand-name {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.nav-links {
+    display: flex;
+    list-style: none;
+    gap: 24px;
+    margin: 0;
+    padding: 0;
+    font-family: 'Montserrat', sans-serif;
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+}
+
+.nav-links a {
+    padding-bottom: 4px;
+    border-bottom: 2px solid transparent;
+    transition: var(--transition);
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+    border-bottom-color: var(--primary);
+}
+
+.cta {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 12px 24px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+}
+
+.cta:hover,
+.cta:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 40px rgba(199, 0, 57, 0.4);
+}
+
+.hero-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 60px;
+    align-items: center;
+    margin-top: 80px;
+    position: relative;
+    z-index: 2;
+}
+
+.hero-copy h1 {
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(3rem, 7vw, 4.8rem);
+    margin: 0 0 24px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.hero-subhead {
+    font-size: 1.12rem;
+    line-height: 1.7;
+    color: var(--text-muted);
+    max-width: 540px;
+    margin-bottom: 32px;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 14px 28px;
+    border-radius: 999px;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: var(--transition);
+}
+
+.btn.primary {
+    background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
+    color: var(--text-light);
+}
+
+.btn.secondary {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.btn.tertiary {
+    padding: 12px 22px;
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.btn:hover,
+.btn:focus {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 30px rgba(0, 0, 0, 0.35);
+}
+
+.trust-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 18px;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.hero-media {
+    display: flex;
+    justify-content: center;
+}
+
+.image-placeholder {
+    width: 100%;
+    aspect-ratio: 4 / 5;
+    border-radius: var(--radius-lg);
+    border: 2px dashed rgba(255, 255, 255, 0.25);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    font-family: 'Montserrat', sans-serif;
+    font-size: 0.9rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    position: relative;
+    overflow: hidden;
+}
+
+.image-placeholder::after {
+    content: attr(data-label);
+    padding: 12px 18px;
+    background: rgba(0, 0, 0, 0.45);
+    border-radius: 999px;
+}
+
+.image-placeholder.wide {
+    aspect-ratio: 16 / 9;
+}
+
+.protocol-card .image-placeholder,
+.card .image-placeholder,
+.journal-card .image-placeholder {
+    margin-bottom: 12px;
+}
+
+.section-heading .image-placeholder {
+    max-width: 520px;
+    margin: 36px auto 0;
+}
+
+.cta-content .image-placeholder {
+    max-width: 520px;
+    margin: 0 auto 36px;
+}
+
+.section {
+    padding: 100px 5vw;
+    position: relative;
+}
+
+.section-heading {
+    max-width: 720px;
+    margin: 0 auto 60px;
+    text-align: center;
+}
+
+.section-heading h2 {
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(2.2rem, 5vw, 3.2rem);
+    margin-bottom: 16px;
+}
+
+.section-heading p {
+    color: var(--text-muted);
+    line-height: 1.7;
+    font-size: 1.05rem;
+}
+
+.eyebrow {
+    display: inline-block;
+    font-family: 'Montserrat', sans-serif;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    color: var(--accent);
+    margin-bottom: 18px;
+}
+
+.card-grid,
+.journal-grid,
+.testimonial-grid,
+.quality-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 28px;
+}
+
+.card,
+.journal-card,
+.quality-card,
+.protocol-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 28px;
+    border-radius: var(--radius-md);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    backdrop-filter: blur(12px);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+}
+
+.card h3,
+.protocol-card h3,
+.journal-card h3,
+.quality-card h3 {
+    font-family: 'Montserrat', sans-serif;
+    margin: 0;
+}
+
+.card p,
+.protocol-card p,
+.journal-card p,
+.quality-card p {
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.text-link {
+    font-family: 'Montserrat', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.78rem;
+    color: var(--primary-light);
+}
+
+.feature {
+    background: linear-gradient(160deg, rgba(20, 20, 22, 0.95) 0%, rgba(14, 7, 12, 0.95) 100%);
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 40px;
+    align-items: center;
+}
+
+.feature-list {
+    list-style: none;
+    margin: 28px 0;
+    padding: 0;
+    display: grid;
+    gap: 16px;
+}
+
+.feature-list li {
+    padding-left: 32px;
+    position: relative;
+    color: var(--text-muted);
+}
+
+.feature-list li::before {
+    content: '';
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
+    position: absolute;
+    left: 0;
+    top: 4px;
+}
+
+.protocols {
+    background: linear-gradient(180deg, rgba(10, 10, 12, 0.95) 0%, rgba(4, 4, 4, 0.95) 100%);
+}
+
+.protocol-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 28px;
+}
+
+.protocol-card {
+    min-height: 220px;
+}
+
+.stats {
+    background: linear-gradient(135deg, rgba(199, 0, 57, 0.95) 0%, rgba(51, 5, 19, 0.95) 100%);
+}
+
+.stats-content {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 60px;
+    text-align: center;
+}
+
+.stat-number {
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(2.5rem, 7vw, 3.8rem);
+    font-weight: 900;
+    letter-spacing: 0.08em;
+}
+
+.stat p {
+    color: rgba(255, 255, 255, 0.85);
+    max-width: 260px;
+    margin-top: 12px;
+}
+
+.testimonials {
+    background: linear-gradient(160deg, rgba(12, 12, 14, 0.96) 0%, rgba(5, 5, 7, 0.94) 100%);
+}
+
+.testimonial-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.testimonial-card {
+    background: var(--card-bg);
+    border-radius: var(--radius-md);
+    padding: 32px;
+    border: 1px solid var(--border-color);
+    color: rgba(255, 255, 255, 0.9);
+    line-height: 1.7;
+    font-style: italic;
+    backdrop-filter: blur(10px);
+}
+
+.testimonial-card cite {
+    display: block;
+    margin-top: 18px;
+    font-style: normal;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.75rem;
+}
+
+.cta-panel {
+    background: linear-gradient(160deg, rgba(12, 12, 14, 0.94) 0%, rgba(199, 0, 57, 0.94) 100%);
+}
+
+.cta-content {
+    max-width: 600px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.cta-actions {
+    display: flex;
+    justify-content: center;
+    gap: 18px;
+    margin-top: 28px;
+}
+
+.faq-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 28px;
+}
+
+details {
+    background: var(--card-bg);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
+    padding: 24px;
+    font-size: 1rem;
+}
+
+details summary {
+    font-family: 'Montserrat', sans-serif;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+
+details p {
+    margin-top: 16px;
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.footer {
+    background: #050506;
+    padding: 80px 5vw 40px;
+}
+
+.footer-grid {
+    max-width: var(--max-width);
+    margin: 0 auto 60px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 36px;
+}
+
+.footer-links ul {
+    list-style: none;
+    padding: 0;
+    margin: 18px 0 0;
+    display: grid;
+    gap: 12px;
+    color: var(--text-muted);
+}
+
+.footer-links h4,
+.footer-cta h4 {
+    font-family: 'Montserrat', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+
+.newsletter {
+    display: flex;
+    gap: 12px;
+    margin-top: 18px;
+}
+
+.newsletter input {
+    flex: 1;
+    padding: 12px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-light);
+}
+
+.newsletter button {
+    padding: 12px 24px;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
+    color: var(--text-light);
+    font-family: 'Montserrat', sans-serif;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+
+.disclaimer {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    margin-top: 12px;
+    line-height: 1.6;
+}
+
+.footer-note {
+    text-align: center;
+    color: rgba(255, 255, 255, 0.35);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-size: 0.68rem;
+}
+
+@media (max-width: 960px) {
+    .nav {
+        flex-wrap: wrap;
+        gap: 20px;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+    }
+
+    .cta {
+        order: 2;
+    }
+
+    .hero {
+        padding-bottom: 80px;
+    }
+}
+
+@media (max-width: 720px) {
+    .hero-content {
+        margin-top: 60px;
+    }
+
+    .image-placeholder {
+        aspect-ratio: 3 / 4;
+    }
+
+    .section {
+        padding: 80px 6vw;
+    }
+}
+
+@media (max-width: 540px) {
+    .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .cta-actions {
+        flex-direction: column;
+    }
+
+    .newsletter {
+        flex-direction: column;
+    }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+        yearEl.textContent = new Date().getFullYear();
+    }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Borscht of Energy | Souped Up.</title>
+    <link rel="stylesheet" href="assets/css/style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet" />
+</head>
+<body>
+    <header class="hero" id="top">
+        <nav class="nav">
+            <div class="logo">
+                <div class="logo-placeholder" data-filename="logo-placeholder.png">Logo Placeholder</div>
+                <span class="brand-name">Borscht of Energy</span>
+            </div>
+            <ul class="nav-links">
+                <li><a href="#products">Products</a></li>
+                <li><a href="#science">Science</a></li>
+                <li><a href="#protocols">Protocols</a></li>
+                <li><a href="#quality">Quality</a></li>
+                <li><a href="#journal">Journal</a></li>
+                <li><a href="#faq">FAQ</a></li>
+            </ul>
+            <a class="cta" href="#shop">Shop</a>
+        </nav>
+        <div class="hero-content">
+            <div class="hero-copy">
+                <p class="eyebrow">Athlete-Grade Nitrate Fuel</p>
+                <h1>Souped Up.</h1>
+                <p class="hero-subhead">Standardized borscht performance nutrition engineered to widen blood vessels, reduce oxygen cost, and keep you sharp for every surge.</p>
+                <div class="hero-actions">
+                    <a class="btn primary" href="#protocols">Find Your Protocol</a>
+                    <a class="btn secondary" href="#science">See the Science</a>
+                </div>
+                <div class="trust-badges">
+                    <span>Informed-Sport</span>
+                    <span>NSF Certified for Sport</span>
+                    <span>Batch-Tested Nitrates</span>
+                </div>
+            </div>
+            <div class="hero-media">
+                <div class="image-placeholder" data-label="Hero Athlete Energy" data-filename="hero-athlete-energy.jpg"></div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section highlights" id="products">
+            <div class="section-heading">
+                <p class="eyebrow">Product Line</p>
+                <h2>Four formats. One nitrate standard.</h2>
+                <p>Every serving delivers the research-backed nitrate dose athletes trust—without the syrupy crash.</p>
+            </div>
+            <div class="card-grid">
+                <article class="card">
+                    <div class="image-placeholder" data-label="Performance Shot" data-filename="product-shot-performance.jpg"></div>
+                    <h3>Performance Borscht Shot</h3>
+                    <p>Clear beet consommé with lemon and dill. ≥500 mg nitrate for pre-race priming.</p>
+                    <a href="#shop" class="text-link">Shop Shots</a>
+                </article>
+                <article class="card">
+                    <div class="image-placeholder" data-label="Borscht Mix" data-filename="product-shot-mix.jpg"></div>
+                    <h3>Borscht Mix Sachets</h3>
+                    <p>Travel-ready powder that reconstitutes into savory nitrate broth for loading blocks.</p>
+                    <a href="#shop" class="text-link">Shop Mix</a>
+                </article>
+                <article class="card">
+                    <div class="image-placeholder" data-label="Savory Gel" data-filename="product-shot-gel.jpg"></div>
+                    <h3>Top-Up Savory Gel</h3>
+                    <p>Isotonic gel delivering nitrate drip plus carbs every 30–45 minutes on course.</p>
+                    <a href="#shop" class="text-link">Shop Gel</a>
+                </article>
+                <article class="card">
+                    <div class="image-placeholder" data-label="Recovery Broth" data-filename="product-shot-broth.jpg"></div>
+                    <h3>Recovery Borscht Broth</h3>
+                    <p>Mineral-rich post-session broth with nitrates and optional protein for full-circle recovery.</p>
+                    <a href="#shop" class="text-link">Shop Broth</a>
+                </article>
+            </div>
+        </section>
+
+        <section class="section feature" id="science">
+            <div class="feature-grid">
+                <div class="feature-media">
+                    <div class="image-placeholder wide" data-label="Nitrate Pathway Diagram" data-filename="science-pathway-diagram.png"></div>
+                </div>
+                <div class="feature-copy">
+                    <p class="eyebrow">The Science</p>
+                    <h2>From beet nitrates to nitric oxide advantage.</h2>
+                    <p>Dietary nitrates concentrate in saliva where oral bacteria convert them to nitrite. Once in circulation, nitrite transforms into nitric oxide, widening blood vessels, improving oxygen delivery, and boosting muscular efficiency.</p>
+                    <ul class="feature-list">
+                        <li>Proven improvements in time-to-exhaustion and power output.</li>
+                        <li>Optimal dosing: 6–12 mmol (372–744 mg) 2–3 hours pre-effort.</li>
+                        <li>Maintain oral microbiome health—skip antibacterial mouthwash pre-session.</li>
+                    </ul>
+                    <a href="#journal" class="btn tertiary">Read Research Summaries</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="section protocols" id="protocols">
+            <div class="section-heading">
+                <p class="eyebrow">Protocol Engine</p>
+                <h2>Dial in your dose for every discipline.</h2>
+                <p>Select your sport, event length, and training phase. We map the nitrate schedule that keeps you Souped Up.</p>
+            </div>
+            <div class="protocol-grid">
+                <div class="protocol-card">
+                    <div class="image-placeholder wide" data-label="Endurance Race Week" data-filename="protocol-endurance.jpg"></div>
+                    <h3>Endurance — Race Week</h3>
+                    <p>Load daily for 7 days, top up 2–3 hours pre-race, and drip gels every 45 minutes.</p>
+                    <a href="#" class="text-link">Download Cycling Playbook</a>
+                </div>
+                <div class="protocol-card">
+                    <div class="image-placeholder wide" data-label="HIIT & Cross-Functional" data-filename="protocol-hiit.jpg"></div>
+                    <h3>HIIT & Cross-Functional</h3>
+                    <p>Shot 2 hours pre-session for nitric oxide priming. Stack recovery broth post-WOD.</p>
+                    <a href="#" class="text-link">View HIIT Schedule</a>
+                </div>
+                <div class="protocol-card">
+                    <div class="image-placeholder wide" data-label="Masters Athletes" data-filename="protocol-masters.jpg"></div>
+                    <h3>Masters Athletes</h3>
+                    <p>Emphasize savory compliance. Combine daily mix with hydration during heat blocks.</p>
+                    <a href="#" class="text-link">Explore Masters Guide</a>
+                </div>
+                <div class="protocol-card">
+                    <div class="image-placeholder wide" data-label="Altitude & Heat Camps" data-filename="protocol-altitude.jpg"></div>
+                    <h3>Altitude & Heat Camps</h3>
+                    <p>Layer recovery broth and mix sachets for sustained vasodilation under stress.</p>
+                    <a href="#" class="text-link">Download Camp Planner</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="section stats" id="proof">
+            <div class="stats-content">
+                <div class="stat">
+                    <span class="stat-number">500mg</span>
+                    <p>Standard nitrate dose per performance shot.</p>
+                </div>
+                <div class="stat">
+                    <span class="stat-number">3x</span>
+                    <p>More savory options than any competitor.</p>
+                </div>
+                <div class="stat">
+                    <span class="stat-number">100%</span>
+                    <p>Lots with published Certificates of Analysis.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section quality" id="quality">
+            <div class="section-heading">
+                <p class="eyebrow">Quality & Trust</p>
+                <h2>Certified for sport, transparent by design.</h2>
+                <p>Every batch is third-party tested with QR-code verification. Clean label ingredients, heavy metal screening, and nitrate assays you can see.</p>
+            </div>
+            <div class="quality-grid">
+                <div class="quality-card">
+                    <h3>Certification Path</h3>
+                    <p>NSF and Informed-Sport testing ensures zero contamination for tested athletes.</p>
+                </div>
+                <div class="quality-card">
+                    <h3>Batch Lookup</h3>
+                    <p>Scan the QR on pack to see nitrate levels, microbial tests, and production date.</p>
+                </div>
+                <div class="quality-card">
+                    <h3>Ingredient Integrity</h3>
+                    <p>Real beet concentrate plus amaranth greens, stabilized with vitamin C.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section journal" id="journal">
+            <div class="section-heading">
+                <p class="eyebrow">Journal & Education</p>
+                <h2>Learn faster. Train smarter.</h2>
+                <p>Fresh content weekly: science explainers, athlete spotlights, and savory fueling recipes.</p>
+            </div>
+            <div class="journal-grid">
+                <article class="journal-card">
+                    <div class="image-placeholder" data-label="Blog Post" data-filename="journal-research.jpg"></div>
+                    <h3>Nitrate Loading: What the Research Says</h3>
+                    <p>Break down the latest meta-analyses on nitric oxide and endurance adaptation.</p>
+                    <a href="#" class="text-link">Read Article</a>
+                </article>
+                <article class="journal-card">
+                    <div class="image-placeholder" data-label="Athlete Story" data-filename="journal-athlete-story.jpg"></div>
+                    <h3>From Kitchen to KOM</h3>
+                    <p>See how elite cyclists integrate savory nitrates into altitude blocks.</p>
+                    <a href="#" class="text-link">Watch Interview</a>
+                </article>
+                <article class="journal-card">
+                    <div class="image-placeholder" data-label="Recipe" data-filename="journal-recipe.jpg"></div>
+                    <h3>Recovery Broth Ritual</h3>
+                    <p>A chef-developed post-session broth to refuel and rehydrate.</p>
+                    <a href="#" class="text-link">Get the Recipe</a>
+                </article>
+            </div>
+        </section>
+
+        <section class="section testimonials" id="testimonials">
+            <div class="section-heading">
+                <p class="eyebrow">Athlete Proof</p>
+                <h2>Trusted by tested pros.</h2>
+                <p>From crit racers to CrossFit finalists, Borscht of Energy keeps athletes compliant and competitive.</p>
+                <div class="image-placeholder wide" data-label="Athlete Collective" data-filename="testimonials-athletes.jpg"></div>
+            </div>
+            <div class="testimonial-grid">
+                <blockquote class="testimonial-card">
+                    <p>“Shots are clean, savory, and deliver the wattage when it counts. No sugar crash mid-stage.”</p>
+                    <cite>— Pro Cyclist, UCI Continental Team</cite>
+                </blockquote>
+                <blockquote class="testimonial-card">
+                    <p>“The gel keeps my intervals sharp without wrecking my palate. Real food makes a difference.”</p>
+                    <cite>— CrossFit Games Athlete</cite>
+                </blockquote>
+                <blockquote class="testimonial-card">
+                    <p>“Daily broth plus mix kept me energized through altitude camp. Love the transparency.”</p>
+                    <cite>— Masters Marathoner</cite>
+                </blockquote>
+            </div>
+        </section>
+
+        <section class="section cta-panel" id="shop">
+            <div class="cta-content">
+                <div class="image-placeholder wide" data-label="Bundle Layout" data-filename="cta-bundle.jpg"></div>
+                <h2>Ready to get Souped Up?</h2>
+                <p>Choose your bundle—Load Week, Pre-Race Duo, or Recovery Ritual—and unlock the savory advantage.</p>
+                <div class="cta-actions">
+                    <a class="btn primary" href="#">Shop Bundles</a>
+                    <a class="btn secondary" href="#">Subscribe & Save 15%</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="section faq" id="faq">
+            <div class="section-heading">
+                <p class="eyebrow">FAQ</p>
+                <h2>Your questions, answered.</h2>
+                <div class="image-placeholder wide" data-label="Savory Comfort" data-filename="faq-savory.jpg"></div>
+            </div>
+            <div class="faq-grid">
+                <details>
+                    <summary>How soon before a session should I drink Borscht of Energy?</summary>
+                    <p>Drink one performance shot 2–3 hours before your key effort or race to align with peak nitric oxide availability.</p>
+                </details>
+                <details>
+                    <summary>Can I combine products?</summary>
+                    <p>Yes. Stack shots with in-race gels for events longer than 90 minutes, and use mix sachets for load weeks.</p>
+                </details>
+                <details>
+                    <summary>Is it safe for tested athletes?</summary>
+                    <p>Every lot is Informed-Sport and NSF certified, with public Certificates of Analysis.</p>
+                </details>
+                <details>
+                    <summary>Why savory?</summary>
+                    <p>Savory nitrates reduce sweetness fatigue, helping athletes maintain compliance in long events.</p>
+                </details>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-grid">
+            <div class="footer-brand">
+                <div class="logo-placeholder small" data-filename="logo-placeholder.png">Logo Placeholder</div>
+                <p>Real food. Real nitrates. No sugar crash.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Explore</h4>
+                <ul>
+                    <li><a href="#products">Products</a></li>
+                    <li><a href="#protocols">Protocols</a></li>
+                    <li><a href="#quality">Quality</a></li>
+                    <li><a href="#journal">Journal</a></li>
+                </ul>
+            </div>
+            <div class="footer-links">
+                <h4>Support</h4>
+                <ul>
+                    <li><a href="#faq">FAQ</a></li>
+                    <li><a href="#">Contact</a></li>
+                    <li><a href="#">Wholesale</a></li>
+                    <li><a href="#">Privacy</a></li>
+                </ul>
+            </div>
+            <div class="footer-cta">
+                <h4>Stay Souped Up</h4>
+                <form class="newsletter">
+                    <input type="email" placeholder="Email address" aria-label="Email address" />
+                    <button type="submit">Join</button>
+                </form>
+                <p class="disclaimer">*Statements not evaluated by the FDA. Not intended to diagnose, treat, cure, or prevent any disease.</p>
+            </div>
+        </div>
+        <p class="footer-note">© <span id="year"></span> Borscht of Energy. All rights reserved.</p>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a single-page marketing site featuring the "Souped Up." hero message, product highlights, science, protocols, and FAQs
- implement modern styling and placeholders for brand imagery, including the upcoming logo asset, plus a lightweight script for the footer year
- document the required art direction with an image sourcing brief that aligns with each on-page placeholder

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e31a957b408320b759242f2f61e0db