### PR TITLE
Adjust image generation aspect resolutions

### DIFF
--- a/generate_images.py
+++ b/generate_images.py
@@ -1,0 +1,82 @@
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+
+from openai import OpenAI
+
+
+ASPECT_TO_SIZE = {
+    "square": "1024x1024",
+    "landscape": "1536x1024",
+    "portrait": "1024x1536",
+}
+
+DATA_FILE = Path(__file__).with_name("images.json")
+OUTPUT_DIR = Path(__file__).parent / "assets" / "images"
+
+
+def load_image_plan():
+    if not DATA_FILE.exists():
+        raise FileNotFoundError(f"Image plan JSON not found at {DATA_FILE}")
+    with DATA_FILE.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def determine_size(aspect):
+    try:
+        return ASPECT_TO_SIZE[aspect]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported aspect '{aspect}'. Expected one of {list(ASPECT_TO_SIZE)}") from exc
+
+
+def generate_image(client, image_spec):
+    image_name = image_spec["image_name"]
+    aspect = image_spec["aspect"]
+    description = image_spec["description"]
+    size = determine_size(aspect)
+
+    print(f"Generating {image_name} ({aspect}, size {size})...")
+    response = client.images.generate(
+        model="gpt-image-1",
+        prompt=description,
+        size=size,
+    )
+
+    image_base64 = response.data[0].b64_json
+    image_bytes = base64.b64decode(image_base64)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = OUTPUT_DIR / image_name
+    with output_path.open("wb") as f:
+        f.write(image_bytes)
+    print(f"Saved {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate images via OpenAI image API")
+    parser.add_argument("image_name", nargs="?", help="Optional specific image filename to generate")
+    args = parser.parse_args()
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY environment variable is not set")
+
+    client = OpenAI(api_key=api_key)
+
+    image_plan = load_image_plan()
+
+    if args.image_name:
+        image_specs = [spec for spec in image_plan if spec["image_name"] == args.image_name]
+        if not image_specs:
+            raise ValueError(f"Image '{args.image_name}' not found in {DATA_FILE}")
+    else:
+        image_specs = image_plan
+
+    for spec in image_specs:
+        generate_image(client, spec)
+
+
+if __name__ == "__main__":
+    main()

--- a/images.json
+++ b/images.json
@@ -1,0 +1,87 @@
+[
+  {
+    "image_name": "hero-athlete-energy.jpg",
+    "aspect": "landscape",
+    "description": "High-contrast twilight scene of an elite endurance cyclist sprinting through a misty urban street, illuminated by crimson neon lights and dynamic motion blur, emphasizing power, speed, and determination."
+  },
+  {
+    "image_name": "product-shot-performance.jpg",
+    "aspect": "portrait",
+    "description": "Macro studio photograph of a 90 mL sleek performance borscht shot bottle with metallic red cap, subtle condensation, faint steam curling upward, and hints of dill garnish on a matte black surface with dramatic rim lighting."
+  },
+  {
+    "image_name": "product-shot-mix.jpg",
+    "aspect": "landscape",
+    "description": "Flat-lay composition of borscht powder sachets on dark slate with beet powder artfully dusted, a polished measuring spoon, glass carafe of hot water, and scattered herb sprigs lit by soft overhead light."
+  },
+  {
+    "image_name": "product-shot-gel.jpg",
+    "aspect": "landscape",
+    "description": "Dynamic action shot of isotonic gel packets mid-air against a dark gradient background with suspended droplets, highlighting portability and savory beet flavors with streaks of crimson light."
+  },
+  {
+    "image_name": "product-shot-broth.jpg",
+    "aspect": "portrait",
+    "description": "Cinematic close-up of recovery borscht broth in a double-walled glass mug with rising steam, surrounded by sliced beets, dill, and peppercorns on a charred wood table lit by warm moody lighting."
+  },
+  {
+    "image_name": "science-pathway-diagram.png",
+    "aspect": "landscape",
+    "description": "Stylized infographic diagram illustrating nitrate to nitrite to nitric oxide pathway with glowing vascular silhouettes of an athlete, molecular icons, and annotated arrows on a dark futuristic grid background."
+  },
+  {
+    "image_name": "protocol-endurance.jpg",
+    "aspect": "landscape",
+    "description": "Montage of endurance cyclists prepping gear at dawn, organizing nutrition bottles and checklists beside their bikes, with cool blue ambient light accented by crimson highlights."
+  },
+  {
+    "image_name": "protocol-hiit.jpg",
+    "aspect": "landscape",
+    "description": "High-intensity training scene in an industrial gym where an athlete chalks hands before a workout, particles suspended in warm red light beams with dramatic shadows."
+  },
+  {
+    "image_name": "protocol-masters.jpg",
+    "aspect": "landscape",
+    "description": "Confident masters athlete stretching on a rooftop at sunrise, city skyline in the background, soft golden light and subtle crimson accents conveying longevity and poise."
+  },
+  {
+    "image_name": "protocol-altitude.jpg",
+    "aspect": "landscape",
+    "description": "Trail runner training at high altitude on a ridge with dramatic snow-capped mountains and crimson dawn sky, emphasizing resilience and adventure."
+  },
+  {
+    "image_name": "journal-research.jpg",
+    "aspect": "landscape",
+    "description": "Editorial laboratory setup with beakers and test tubes containing vivid beet pigments under neon magenta and teal lighting, highlighting scientific rigor."
+  },
+  {
+    "image_name": "journal-athlete-story.jpg",
+    "aspect": "portrait",
+    "description": "Portrait of elite triathlete smiling post-race with medal and branded borscht bottle, sweat glistening and background blurred stadium lights."
+  },
+  {
+    "image_name": "journal-recipe.jpg",
+    "aspect": "landscape",
+    "description": "Overhead shot of vibrant beet soup garnished with dill, citrus zest, and a dollop of yogurt on a dark stone table with rustic spoons and sliced rye bread."
+  },
+  {
+    "image_name": "testimonials-athletes.jpg",
+    "aspect": "landscape",
+    "description": "Collage of diverse athlete headshots arranged in geometric grid with subtle brand gradient overlay of deep reds and purples, conveying community and trust."
+  },
+  {
+    "image_name": "cta-bundle.jpg",
+    "aspect": "landscape",
+    "description": "Product bundle arrangement featuring bottles, gel packets, and powder sachets on a matte black surface with glowing rim light, condensation, and bold shadows."
+  },
+  {
+    "image_name": "faq-savory.jpg",
+    "aspect": "portrait",
+    "description": "Cozy close-up of athlete's hands cradling a steaming savory borscht mug, showing texture of the drink and soft knit sleeves in warm lighting."
+  },
+  {
+    "image_name": "logo-placeholder.png",
+    "aspect": "square",
+    "description": "Minimalist Borscht of Energy logo featuring stylized beet lightning bolt icon and modern sans-serif typography in deep crimson on transparent background."
+  }
+]


### PR DESCRIPTION
## Summary
- add a JSON plan describing all required marketing images with aspect ratios and prompts
- add a Python utility that reads the plan and generates images through the OpenAI gpt-image-1 API
- adjust landscape and portrait resolution mappings to 1536x1024 and 1024x1536 to match requirements

## Testing
- python -m compileall generate_images.py

------
https://chatgpt.com/codex/tasks/task_e_68e32a7cf7048320b150769bc2ad3159