### PR TITLE
Load generated images into placeholders

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -100,6 +100,8 @@ a:focus {
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--text-muted);
+    background: rgba(255, 255, 255, 0.04);
+    overflow: hidden;
 }
 
 .logo-placeholder.small {
@@ -254,6 +256,23 @@ a:focus {
     text-transform: uppercase;
     position: relative;
     overflow: hidden;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.image-placeholder img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.image-placeholder.has-image {
+    border: none;
+    background: none;
+}
+
+.image-placeholder.has-image::after {
+    display: none;
 }
 
 .image-placeholder::after {
@@ -281,6 +300,18 @@ a:focus {
 .cta-content .image-placeholder {
     max-width: 520px;
     margin: 0 auto 36px;
+}
+
+.logo-placeholder.has-image {
+    border: none;
+    background: none;
+}
+
+.logo-placeholder img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
 }
 
 .section {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,4 +3,38 @@ document.addEventListener('DOMContentLoaded', () => {
     if (yearEl) {
         yearEl.textContent = new Date().getFullYear();
     }
+
+    const placeholders = document.querySelectorAll(
+        '.image-placeholder[data-filename], .logo-placeholder[data-filename]'
+    );
+
+    placeholders.forEach((placeholder) => {
+        const filename = placeholder.dataset.filename;
+        if (!filename) {
+            return;
+        }
+
+        const fallbackContent = placeholder.innerHTML;
+        const isLogo = placeholder.classList.contains('logo-placeholder');
+        const label = placeholder.dataset.label || placeholder.textContent.trim();
+        const altText = isLogo ? 'Borscht of Energy logo' : label || '';
+
+        const img = new Image();
+        img.decoding = 'async';
+        img.loading = placeholder.closest('.hero') ? 'eager' : 'lazy';
+        img.alt = altText;
+
+        img.addEventListener('load', () => {
+            placeholder.innerHTML = '';
+            placeholder.appendChild(img);
+            placeholder.classList.add('has-image');
+        });
+
+        img.addEventListener('error', () => {
+            placeholder.classList.remove('has-image');
+            placeholder.innerHTML = fallbackContent;
+        });
+
+        img.src = `assets/images/${filename}`;
+    });
 });


### PR DESCRIPTION
## Summary
- style placeholder containers so generated assets can fill their frames with cover sizing
- inject generated images at runtime while preserving fallback content when files are missing

## Testing
- python -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68e331fb11f88320b86c5edbd9e9eedc